### PR TITLE
Doc pour paramètres "animate" et "duration"

### DIFF
--- a/docs/doc_dev/config_search.rst
+++ b/docs/doc_dev/config_search.rst
@@ -58,11 +58,18 @@ Options liées à  la recherche d'adresse *(olscompletion)* et à  la recherch
 .. code-block:: xml
        :linenos:
 	
-	   <searchparameters bbox="" localities="" features="" static=""/>
+	   <searchparameters bbox="" localities="" features="" static="" animate="" duration=""/>
 
 **Attributs**
 
 * ``bbox`` *(optionnel)* : Recherche d'adresse et/ou d'entitées dans l'emprise de la carte : true ou false (defaut = false),
 * ``localities`` *(optionnel)* : Utilisation du service d'adresse olscompletion : true ou false (defaut = true),
 * ``features`` *(optionnel)* : Utilisation du service de recherche d'entitées elasticsearch : true ou false (defaut = true),
-* ``static`` *(optionnel)* : En lien avec le paramètre doctypes. Active ou désactive la recherche associée à  des documents requêtés systématiquement, indépendamment des couches affichées : true ou false (defaut = false).
+* ``static`` *(optionnel)* : En lien avec le paramètre doctypes. Active ou désactive la recherche associée à des documents requêtés systématiquement, indépendamment des couches affichées : true ou false (defaut = false),
+* ``animate`` *(optionnel)* : Active ou désactive l'animation de la vue lorsqu'un résultat de recherche est sélectionné  : true ou false (defaut = false),
+
+.. image:: ../_images/dev/config_search/option-animate.gif
+            :alt: activation de l'option animate
+            :align: center
+
+* ``duration`` *(optionnel)* : Durée en ms de l'animation définie dans l'option 'animate' (defaut = 1000).


### PR DESCRIPTION
Ajout de documentation pour les paramètres : 
- `animate`
- `duration`

// PR #197 du mviewer