### PR TITLE
Ajout paramètre exclusive dans les paramètres de layers

### DIFF
--- a/docs/doc_dev/config_layers.rst
+++ b/docs/doc_dev/config_layers.rst
@@ -237,6 +237,7 @@ Elément enfant de ``<theme>`` ou ``<group>``
 * ``scalemin``: Echelle minimum de la couche
 * ``scalemax``: Echelle maximum de la couche
 * ``visible``:  Booléen stipulant est ce que la couche est actuellement visible
+* ``exclusive``:  Booléen stipulant si la couche est exclusive. Si la valeur est "true", l'affichage de cette couche masquera automatiquement toutes les autres couches ayant le paramètre ``exclusive``
 * ``style``: Style(s) de la couche. Si plusieurs styles , utiliser la virgule comme séparateur. Si la couche est de type wms, il faut faire référence à un style sld. Si la couche est de type geojson, il faut faire référence à un style définit dans lib/featurestyles.js. Si la couche est de type customlayer, le style n'est pas défini ici.
 * ``stylesalias``: Titres à utiliser pour chaques style. utiliser la virgule comme séparateur si plusieurs styles.
 * ``sld``: Lien vers un SLD stocké sur le web. Dans ce fichier SLD, la balise sld:Name contenue dans sld:NamedLayer doit être égale au nom de la couche.


### PR DESCRIPTION
Ajout de la description du paramètre "exclusive" à la documentation de la configuration des couches. Fichier config_layers.rst